### PR TITLE
Changed Matplotlib to version 3.0.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Pillow==6.2.1
 scikit-learn
 toposort
 fastcluster
-matplotlib==3.1.1
+matplotlib==3.0.3
 imageio==2.6.1
 imageio-ffmpeg
 ffmpy==0.2.2


### PR DESCRIPTION
The current version has no install candidate via pip on docker, ubuntu 16 18 19. 
I tried using matplotlib 3.0.3 and it seems to work (not completely tested)